### PR TITLE
Exposing axis.orient()

### DIFF
--- a/src/axis.js
+++ b/src/axis.js
@@ -116,6 +116,16 @@ function axis(orient, scale) {
     selection
         .each(function() { this.__axis = position; });
   }
+  
+  axis.orient = function() {
+      switch (orient) {
+          case top: return 'top';
+          case bottom: return 'bottom';
+          case left: return 'left';
+          case right: return 'right';
+          default:
+      }
+  }
 
   axis.scale = function(_) {
     return arguments.length ? (scale = _, axis) : scale;


### PR DESCRIPTION
Any helpers or otherwise around working with axis are going to want to have access to the orientation.

If I write a layout library to help compose charts, or something similar, knowing what orientation an axis object is when passed in is absolutely useful.

Some other way of doing a typecheck or something other than just a getter would be good, too. But this seems straightforward and useful to inspect the orientation of a generic axis.