### PR TITLE
Factor out x, y, and k to axis constructor

### DIFF
--- a/src/axis.js
+++ b/src/axis.js
@@ -33,7 +33,9 @@ function axis(orient, scale) {
       tickFormat = null,
       tickSizeInner = 6,
       tickSizeOuter = 6,
-      tickPadding = 3;
+      tickPadding = 3,
+      k = orient === top || orient === left ? -1 : 1,
+      x, y = orient === left || orient === right ? (x = "x", "y") : (x = "y", "x");
 
   function axis(context) {
     var values = tickValues == null ? (scale.ticks ? scale.ticks.apply(scale, tickArguments) : scale.domain()) : tickValues,
@@ -50,9 +52,7 @@ function axis(orient, scale) {
         tickExit = tick.exit(),
         tickEnter = tick.enter().append("g").attr("class", "tick"),
         line = tick.select("line"),
-        text = tick.select("text"),
-        k = orient === top || orient === left ? -1 : 1,
-        x, y = orient === left || orient === right ? (x = "x", "y") : (x = "y", "x");
+        text = tick.select("text");
 
     path = path.merge(path.enter().insert("path", ".tick")
         .attr("class", "domain")


### PR DESCRIPTION
I was studying the axis implementation and happened to notice that the computed `x`, `y`, and `k` values will always be the same on each invocation, as them stem from `orient` which is constant. Therefore their computation can be moved out of the render function and into the constructor.

Not sure if this is a considerable win, but I just thought I'd propose the change.

Verified that the tests still pass.