### PR TITLE
prototype demonstrating d3fc-scripts (create-d3-module)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,0 @@
-parserOptions:
-    sourceType: module
-
-extends:
-    "eslint:recommended"
-
-rules:
-    no-cond-assign: 0

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./node_modules/d3fc-scripts/.eslintrc.json"
+}

--- a/package.json
+++ b/package.json
@@ -23,19 +23,12 @@
     "url": "https://github.com/d3/d3-axis.git"
   },
   "scripts": {
-    "pretest": "rm -rf build && mkdir build && rollup --banner \"$(preamble)\" -f umd -n d3 -o build/d3-axis.js -- index.js",
-    "test": "tape 'test/**/*-test.js' && eslint index.js src",
-    "prepublish": "npm run test && uglifyjs --preamble \"$(preamble)\" build/d3-axis.js -c -m -o build/d3-axis.min.js",
-    "postpublish": "git push && git push --tags && cd ../d3.github.com && git pull && cp ../d3-axis/build/d3-axis.js d3-axis.v1.js && cp ../d3-axis/build/d3-axis.min.js d3-axis.v1.min.js && git add d3-axis.v1.js d3-axis.v1.min.js && git commit -m \"d3-axis ${npm_package_version}\" && git push && cd - && zip -j build/d3-axis.zip -- LICENSE README.md build/d3-axis.js build/d3-axis.min.js"
+    "test": "d3fc-scripts test",
+    "bundle": "d3fc-scripts bundle"
   },
   "devDependencies": {
     "d3-scale": "1",
     "d3-selection": "^1.1.0",
-    "eslint": "3",
-    "jsdom": "11",
-    "package-preamble": "0.1",
-    "rollup": "0.42",
-    "tape": "4",
-    "uglify-js": "^2.8.11"
+    "d3fc-scripts": "git://github.com/ColinEberhardt/d3fc-scripts.git#d3-module"
   }
 }


### PR DESCRIPTION
This pull request is a quick prototype to show the use of d3fc-scripts, a create-react-app style approach to d3 modules, as discussed here: https://github.com/d3/d3/issues/3116

The general concept is to centralise common infrastructure (build, test, lint, ...) into a single package for easier maintenance and the creation of new modules without cut-and-paste.

We've been using this approach within [d3fc](https://github.com/d3fc) for a little while, via [d3fc-scripts](https://github.com/d3fc/d3fc-scripts). While some of our choices differ from those in d3 (jasmine vs tape, ES201* vs ES2015) the general principles are the same.

I've created a branch of d3fc-scripts, tailoring for the current d3 projects, as a proof of concept. This PR demonstrates the following:

 - The removal of common infrastructure dependencies from d3-axis
 - The removal of common build scripts from d3-axis

d3fc-scripts performs the following:
 - bundling, using rollup and uglify
 - linting
 - unit test execution
 - static checks for project meta-data (licence files, npmignore etc ...)

Basically anything that can be centralised is moved to d3fc-scripts, anything that cannot is checked via the tests.

If this looks like a good approach, I'd propose to:

 - resolve the differences between d3fc and d3 in terms of testing and JavaScript syntax, either by making d3fc-scripts configurable, or updating the d3fc modules to match d3
 - look at the publishing step, for d3fc we use semantic-release
 - document d3fc-scripts!
 - make sure it works for other module authors.