### PR TITLE
Added transformation of tick text enabling smarter tick text during a…

### DIFF
--- a/src/axis.js
+++ b/src/axis.js
@@ -37,6 +37,7 @@ function axis(orient, scale) {
   var tickArguments = [],
       tickValues = null,
       tickFormat = null,
+      tickTextTransform = null,
       tickSizeInner = 6,
       tickSizeOuter = 6,
       tickPadding = 3,
@@ -73,7 +74,8 @@ function axis(orient, scale) {
     text = text.merge(tickEnter.append("text")
         .attr("fill", "#000")
         .attr(x, k * spacing)
-        .attr("dy", orient === top ? "0em" : orient === bottom ? "0.71em" : "0.32em"));
+        .attr("dy", orient === top ? "0em" : orient === bottom ? "0.71em" : "0.32em"))
+        .style('transform', tickTextTransform);
 
     if (context !== selection) {
       path = path.transition(context);
@@ -120,6 +122,10 @@ function axis(orient, scale) {
 
   axis.scale = function(_) {
     return arguments.length ? (scale = _, axis) : scale;
+  };
+
+  axis.tickTextTransform = function(_) {
+    return arguments.length ? (tickTextTransform = _, axis) : tickTextTransform;
   };
 
   axis.ticks = function() {


### PR DESCRIPTION
With this feature, the user can transform the text for each tick to enable smarter ticks, especially when the tick texts are really long or the animation is to be applied gradually. Currently, to do this, the user would have to write his own ticking logic. This way, the ticks can be transformed as per the user's requirement without having to write extra code for it. 
We have used this version of the text transformation to create multi-line tick texts and even shifting labels to create higher end visualisations. You could check it out in https://github.com/chartshq/muze 