### PR TITLE
Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,19 @@ If *size* is specified, sets the inner tick size to the specified value and retu
 
 If *size* is specified, sets the outer tick size to the specified value and returns the axis. If *size* is not specified, returns the current outer tick size, which defaults to 6. The outer tick size controls the length of the square ends of the domain path, offset from the native position of the axis. Thus, the “outer ticks” are not actually ticks but part of the domain path, and their position is determined by the associated scale’s domain extent. Thus, outer ticks may overlap with the first or last inner tick. An outer tick size of 0 suppresses the square ends of the domain path, instead producing a straight line.
 
+<a name="axis_tickReach" href="#axis_tickReach">#</a> <i>axis</i>.<b>tickReach</b>([<i>reach</i>]) · [Source](https://github.com/d3/d3-axis/blob/master/src/axis.js)
+
+If *reach* is specified, sets the tick reach to the specified value and returns the axis. If *reach* is not specified, returns the current inner tick reach, which defaults to 0. The tick reach controls the length of the tick lines beyond the axis’ native position, and can be set to a chart’s width to create a grid.
+
 <a name="axis_tickPadding" href="#axis_tickPadding">#</a> <i>axis</i>.<b>tickPadding</b>([<i>padding</i>]) · [Source](https://github.com/d3/d3-axis/blob/master/src/axis.js)
 
-If *padding* is specified, sets the padding to the specified value in pixels and returns the axis. If *padding* is not specified, returns the current padding which defaults to 3 pixels.
+If *padding* is specified, sets the text padding to the specified value in pixels and returns the axis. If *padding* is not specified, returns the current padding which defaults to 3 pixels.
+
+<a name="axis_title" href="#axis_title">#</a> <i>axis</i>.<b>title</b>([<i>title</i>]) · [Source](https://github.com/d3/d3-axis/blob/master/src/axis.js)
+
+If a *title* is specified, sets the title and returns the axis. Otherwise returns the title. If the title is not `null`, a text element will be created near the far end of the axis, with a class `title` and a text content set to the title.
+
+<a name="axis_filter" href="#axis_filter">#</a> <i>axis</i>.<b>filter</b>([<i>filter</i>]) · [Source](https://github.com/d3/d3-axis/blob/master/src/axis.js)
+
+If a *filter* is specified, sets the filter and returns the axis. The filter is a function that returns a truthy value for all elements that must be displayed, with an argument of `domain`, `line` or `text`. Defaults to `function(type) { return true; }`.
+

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ The axis component renders human-readable reference marks for [scales](https://g
 
 ## Installing
 
-If you use NPM, `npm install d3-axis`. Otherwise, download the [latest release](https://github.com/d3/d3-axis/releases/latest). You can also load directly from [d3js.org](https://d3js.org), either as a [standalone library](https://d3js.org/d3-axis.v1.min.js) or as part of [D3](https://github.com/d3/d3). (To be useful, you’ll also want to use [d3-scale](https://github.com/d3/d3-scale) and [d3-selection](https://github.com/d3/d3-selection), but these are soft dependencies.) AMD, CommonJS, and vanilla environments are supported. In vanilla, a `d3` global is exported:
+If you use NPM, `npm install d3-axis`. Otherwise, download the [latest release](https://github.com/d3/d3-axis/releases/latest). You can also load directly from [d3js.org](https://d3js.org), either as a [standalone library](https://d3js.org/d3-axis.v2.min.js) or as part of [D3](https://github.com/d3/d3). (To be useful, you’ll also want to use [d3-scale](https://github.com/d3/d3-scale) and [d3-selection](https://github.com/d3/d3-selection), but these are soft dependencies.) AMD, CommonJS, and vanilla environments are supported. In vanilla, a `d3` global is exported:
 
 ```html
-<script src="https://d3js.org/d3-axis.v1.min.js"></script>
+<script src="https://d3js.org/d3-axis.v2.min.js"></script>
 <script>
 
 var axis = d3.axisLeft(scale);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "d3-scale": "2 - 3",
-    "d3-selection": "^1.1.0",
+    "d3-selection": "^1.1.0 - 2",
     "eslint": "6",
     "jsdom": "15",
     "rollup": "1",

--- a/src/axis.js
+++ b/src/axis.js
@@ -16,9 +16,7 @@ function translateY(y) {
 }
 
 function number(scale) {
-  return function(d) {
-    return +scale(d);
-  };
+  return d => +scale(d);
 }
 
 function center(scale) {

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,0 +1,1 @@
+export default x => () => x;

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,10 +293,10 @@ d3-interpolate@1:
     d3-time "1"
     d3-time-format "2"
 
-d3-selection@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.0.tgz#ab9ac1e664cf967ebf1b479cc07e28ce9908c474"
-  integrity sha512-EYVwBxQGEjLCKF2pJ4+yrErskDnz5v403qvAid96cNdCMr8rmCYfY5RGzWz24mdIbxmDf6/4EAH+K9xperD5jg==
+"d3-selection@^1.1.0 - 2":
+  version "2.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-2.0.0-rc.2.tgz#530fffde9fc6007d90c79d39bc4b2777e7288f6e"
+  integrity sha512-3sXAgCMsIi6zmZFGwgI2fFi9f99vzBRUKZoKOJq8yWDDAci00QgJQfe7xW0VqUW2hItUvGVl61M8WY4Cxg8soQ==
 
 d3-time-format@2:
   version "2.1.3"


### PR DESCRIPTION
Here's a proposal for #64 

## title

axis.title([*title*]) sets a title, which creates a text element towards the tip of the axis.

- The precise positioning is not as beautiful as in the https://observablehq.com/@d3/scatterplot example because we don't usually have a nice arrow which wants a bit more margin.


## filter

axis.filter([*filter*]) allows to set a filter which will control the rendering of `domain`, tick `line` and `text`

- Initially I wanted to make it depend on the datum, but it would mean to recheck each existing tick (line or text) to see if it still matches the filter, so maybe that's too much.


## reach

axis.reach([*reach*]) allows to set a reach, which is like the innerSize, but in the opposite direction (into the chart), allowing to create a grid from the tick lines by calling e.g. `axis.reach(width)`

- I'm not sure about the name 
- I'm not sure if this shouldn't be another layer of the axis (filter out by default if reach===0)


These options are demoed at https://observablehq.com/d/2e8bc58f05a8037a