### PR TITLE
Fixes orient comparison to be always strict equal.

### DIFF
--- a/src/axis.js
+++ b/src/axis.js
@@ -91,7 +91,7 @@ function axis(orient, scale) {
     tickExit.remove();
 
     path
-        .attr("d", orient === left || orient == right
+        .attr("d", orient === left || orient === right
             ? (tickSizeOuter ? "M" + k * tickSizeOuter + "," + range0 + "H0.5V" + range1 + "H" + k * tickSizeOuter : "M0.5," + range0 + "V" + range1)
             : (tickSizeOuter ? "M" + range0 + "," + k * tickSizeOuter + "V0.5H" + range1 + "V" + k * tickSizeOuter : "M" + range0 + ",0.5H" + range1));
 


### PR DESCRIPTION
Just a small fix when comparing orientations, nothing much to say. All the code that compares the `orient` variable uses `'===' `so in order to be consistent it makes sense to use it also here.